### PR TITLE
Unscrollable side menu

### DIFF
--- a/_includes/sidemenu-documentation.html
+++ b/_includes/sidemenu-documentation.html
@@ -1,4 +1,4 @@
-<ul class="sidenav dropable sticky">
+<ul class="sidenav dropable">
 	<li class="{% if page.ref == 'index' %}active{% endif %}">
 				<a href="{{ site.baseurl }}/{{ site.index[page.lang] }}">{{ site.documentation-pages.overview.title[page.lang]}}</a>
 		</li>


### PR DESCRIPTION
@medikoo unsure to whom should I assign this.

Steps to reproduce:

1. Go to http://help.eregistrations.org/ .
2. Click "Framework" in the left menu.

The menu unfolds, some elements do not fit the screen.... however no scrolling is available, hence leaving user in situation where he cannot reach last elements.

![image](https://cloud.githubusercontent.com/assets/7392217/21015204/5dbcce24-bd61-11e6-9c28-6c0adaf701ea.png)
